### PR TITLE
feat(ui): improve BottomPlayerBar interactions and alignment

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+MusicApp

--- a/.idea/planningMode.xml
+++ b/.idea/planningMode.xml
@@ -4,6 +4,7 @@
     <option name="approvalStates">
       <map>
         <entry key="20260427-174713-c06a3791-ac07-4950-8edb-857be1191790" value="true" />
+        <entry key="20260428-103500-395a67c4-9b99-49c0-addd-e199b286c739" value="true" />
       </map>
     </option>
   </component>

--- a/app/src/main/java/com/example/musicapp/ui/components/player/BottomPlayerBar.kt
+++ b/app/src/main/java/com/example/musicapp/ui/components/player/BottomPlayerBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -20,6 +21,25 @@ import com.example.musicapp.ui.theme.BgMedium
 
 @Composable
 fun BottomPlayerBar(onShowSongInfo: () -> Unit = {}) {
+    var isRepeatActive by remember { mutableStateOf(false) }
+    var isVectoreActive by remember { mutableStateOf(false) }
+    var skipPrevFlash by remember { mutableStateOf(false) }
+    var skipNextFlash by remember { mutableStateOf(false) }
+
+    LaunchedEffect(skipPrevFlash) {
+        if (skipPrevFlash) {
+            delay(200)
+            skipPrevFlash = false
+        }
+    }
+
+    LaunchedEffect(skipNextFlash) {
+        if (skipNextFlash) {
+            delay(200)
+            skipNextFlash = false
+        }
+    }
+
     Surface(
         color = BgMedium,
         modifier = Modifier.fillMaxWidth().height(64.dp)
@@ -27,7 +47,7 @@ fun BottomPlayerBar(onShowSongInfo: () -> Unit = {}) {
         Row(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 8.dp),
+                .padding(horizontal = 4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             // Group 1: Play, Repeat, Prev (Left side)
@@ -36,41 +56,47 @@ fun BottomPlayerBar(onShowSongInfo: () -> Unit = {}) {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
-                IconButton(onClick = { }, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = { }, modifier = Modifier.size(40.dp)) {
                     Icon(
                         imageVector = Icons.Default.PlayArrow,
                         contentDescription = null,
                         tint = AccentOrange,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(24.dp)
                     )
                 }
-                IconButton(onClick = { }, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = { isRepeatActive = !isRepeatActive }, modifier = Modifier.size(40.dp)) {
                     Icon(
                         painter = painterResource(id = R.drawable.material_symbols_repeat),
                         contentDescription = null,
-                        tint = AccentOrange,
-                        modifier = Modifier.size(18.dp)
+                        tint = if (isRepeatActive) Color.White else AccentOrange,
+                        modifier = Modifier.size(22.dp)
                     )
                 }
-                IconButton(onClick = { }, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = { skipPrevFlash = true }, modifier = Modifier.size(40.dp)) {
                     Icon(
                         painter = painterResource(id = R.drawable.skip_next),
                         contentDescription = null,
-                        tint = AccentOrange,
-                        modifier = Modifier.size(18.dp)
+                        tint = if (skipPrevFlash) Color.White else AccentOrange,
+                        modifier = Modifier.size(22.dp)
                     )
                 }
             }
 
             // Center: Song Title (Fixed center position)
-            Text(
-                text = "Singer - Song Title",
-                color = Color.White,
-                fontSize = 13.sp,
-                fontWeight = FontWeight.Bold,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = 4.dp)
-            )
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Singer - Song Title",
+                    color = Color.White,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    modifier = Modifier.padding(horizontal = 2.dp)
+                )
+            }
 
             // Group 2: Next, Shuffle, Up (Right side)
             Row(
@@ -78,28 +104,28 @@ fun BottomPlayerBar(onShowSongInfo: () -> Unit = {}) {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
-                IconButton(onClick = { }, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = { skipNextFlash = true }, modifier = Modifier.size(40.dp)) {
                     Icon(
                         painter = painterResource(id = R.drawable.skip_next1),
                         contentDescription = null,
-                        tint = AccentOrange,
-                        modifier = Modifier.size(18.dp)
+                        tint = if (skipNextFlash) Color.White else AccentOrange,
+                        modifier = Modifier.size(22.dp)
                     )
                 }
-                IconButton(onClick = { }, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = { isVectoreActive = !isVectoreActive }, modifier = Modifier.size(40.dp)) {
                     Icon(
                         painter = painterResource(id = R.drawable.vector),
                         contentDescription = null,
-                        tint = AccentOrange,
-                        modifier = Modifier.size(18.dp)
+                        tint = if (isVectoreActive) Color.White else AccentOrange,
+                        modifier = Modifier.size(22.dp)
                     )
                 }
-                IconButton(onClick = onShowSongInfo, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = onShowSongInfo, modifier = Modifier.size(40.dp)) {
                     Icon(
                         imageVector = Icons.Default.KeyboardArrowUp,
                         contentDescription = null,
                         tint = AccentOrange,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(24.dp)
                     )
                 }
             }


### PR DESCRIPTION
- Implement toggle states (Orange/White) for Repeat and Shuffle buttons
- Add temporary white flash effect for Skip Next/Previous buttons
- Refactor layout with weighted sections for perfect title centering
- Standardize icon and button sizes for visual consistency
- Note: Play button functionality is not yet implemented